### PR TITLE
fix(docker): modernize Dockerfile to use supported Debian repos

### DIFF
--- a/dim/Dockerfile
+++ b/dim/Dockerfile
@@ -1,26 +1,25 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHON_VERSION=3.9.2
-FROM python:${PYTHON_VERSION}-slim
+ARG PYTHON_VERSION=3.9-slim-bullseye
+FROM python:${PYTHON_VERSION}
 
+# Install build dependencies and MariaDB client (replacement for libmysqlclient-dev)
 RUN apt update \
     && apt install --no-install-suggests --no-install-recommends -y \
-    pkg-config gcc curl wget gnupg lsb-release python3-dev \
-    && apt-key del 'A4A9 4068 76FC BD3C 4567  70C8 8C71 8D3B 5072 E1F5' \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C \
-    && curl -sLo mysql.deb https://dev.mysql.com/get/mysql-apt-config_0.8.19-1_all.deb \
-    && DEBIAN_FRONTEND=noninteractive dpkg -i mysql.deb \
-    && rm mysql.deb \
-    && apt update \
-    && apt -y install libmysqlclient-dev \
-    && apt purge -y pkg-config curl wget gnupg lsb-release python3-dev
+    pkg-config gcc curl wget gnupg lsb-release python3-dev libmariadb-dev libmariadb-dev-compat \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
+# Install Python dependencies
 RUN --mount=type=bind,source=requirements.txt,target=requirements.txt \
-    python -m pip install -r requirements.txt
+    python -m pip install --no-cache-dir -r requirements.txt \
+    && apt purge -y pkg-config gcc curl wget gnupg lsb-release python3-dev \
+    && apt autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
 
+# Create non-root user
 ARG UID=10001
 RUN adduser \
     --disabled-password \
@@ -39,4 +38,4 @@ COPY --chown=dimuser:dimuser . .
 
 USER dimuser
 
-CMD gunicorn 'app:application' -w 4 -b :8000
+CMD ["gunicorn", "app:application", "-w", "4", "-b", ":8000"]


### PR DESCRIPTION
## Summary
- Upgrade from deprecated Debian Buster (python:3.9.2-slim) to Bullseye to resolve 404 repository errors
- Replace MySQL client installation with MariaDB equivalent for better compatibility and reduced complexity

## Changes Made
- **Base image upgrade**: Changed from `python:3.9.2-slim` (Debian Buster) to `python:3.9-slim-bullseye`
- **Repository fix**: Removed complex MySQL repository setup that was failing due to deprecated Buster repos
- **MySQL client replacement**: Switched from `libmysqlclient-dev` to `libmariadb-dev` and `libmariadb-dev-compat`
- **Build optimization**: Simplified package installation and added proper cleanup with `apt autoremove` and cache clearing
- **CMD format fix**: Changed to JSON array format for better signal handling

## Test plan
- [ ] Verify Docker build completes successfully without repository errors
- [ ] Test that MySQL connectivity still works with MariaDB client libraries
- [ ] Confirm application starts and runs correctly in the container
- [ ] Validate that all Python dependencies install without issues